### PR TITLE
Expose Result for Post Processing

### DIFF
--- a/PluploadHandler.php
+++ b/PluploadHandler.php
@@ -232,12 +232,12 @@ class PluploadHandler {
 			@fclose($in);
 
 			// chunk is not required anymore
-			if (self::$conf['cleanup']) @unlink($chunk_path);
+			@unlink($chunk_path);
 		}
 		@fclose($out);
 
 		// Cleanup
-		if (self::$conf['cleanup']) self::rrmdir($chunk_dir);
+		self::rrmdir($chunk_dir);
 	}
 
 
@@ -276,7 +276,7 @@ class PluploadHandler {
 	}
 
 
-	public static function cleanup() 
+	private static function cleanup() 
 	{
 		// Remove old temp files	
 		if (file_exists(self::$conf['target_dir'])) {


### PR DESCRIPTION
If a user needs to manipulate the files after upload (to generate thumbnails, apply watermarks, etc), the resulting file paths should be exposed. These paths cannot be guessed from the request because the handler sanitizes the file name. This update also exposes a "complete" status to easily determine if the file has been uploaded and combined.
